### PR TITLE
Fix for libboost1.58

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,18 @@ cd src
 strip gamecreditsd
 ```
 
+### If Ubuntu >= 16.04 (libboost=1.58)
+```
+cd GameCredits
+git checkout ubuntu16.04
+./autogen.sh
+./configure CXXFLAGS="$CXXFLAGS -DBOOST_VARIANT_USE_RELAXED_GET_BY_DEFAULT=1 -fPIC" --with-incompatible-bdb
+make
+cd src
+strip gamecreditsd
+```
+
+
 ###Compile gamecreditsd with Berkeley DB 4.8 Recommended
 ```
 cd GameCredits

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -297,7 +297,7 @@ Value listunspent(const Array& params, bool fHelp)
             CTxDestination address;
             if (ExtractDestination(pk, address))
             {
-                const CScriptID& hash = boost::get<const CScriptID&>(address);
+                const CScriptID& hash = boost::get<CScriptID&>(address);
                 CScript redeemScript;
                 if (pwalletMain->GetCScript(hash, redeemScript))
                     entry.push_back(Pair("redeemScript", HexStr(redeemScript.begin(), redeemScript.end())));


### PR DESCRIPTION
Compilation fails with libboost1.58 and you can't install 1.54 on
Ubuntu 16.04. I copied the code from this pull request in the
bitcoin repo https://github.com/bitcoin/bitcoin/pull/6114/files.
In order to compile it you have to run configure with additional
parameters (I added them to the readme.md in the ubuntu16.04 branch)